### PR TITLE
Build on local dir instead of temp one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
   only:
     - master
 install:
-  - bundle install
+  - gem update --system && gem install bundler && bundle install
 matrix:
   fast_finish: true
   allow_failures:

--- a/bash/deploy.sh
+++ b/bash/deploy.sh
@@ -9,13 +9,7 @@ BRANCH=$2
 TEMP=$(mktemp -d -t mgd-XXX)
 trap 'rm -rf ${TEMP}' EXIT
 CLONE=${TEMP}/clone
-COPY=${TEMP}/copy
-
-echo -e "Cloning Github repository:"
-git clone "${URL}" "${CLONE}"
-cp -R "${CLONE}" "${COPY}"
-
-cd "${CLONE}"
+ORIGIN=$(pwd)
 
 echo -e "\nBuilding Middleman site:"
 rm -rf build
@@ -26,11 +20,8 @@ if [ ! -e build ]; then
   exit -1
 fi
 
-cp -R build "${TEMP}"
-
-cd "${TEMP}"
-rm -rf "${CLONE}"
-mv "${COPY}" "${CLONE}"
+echo -e "\nCloning Github repository:"
+git clone "${URL}" "${CLONE}"
 cd "${CLONE}"
 
 echo -e "\nPreparing ${BRANCH} branch:"
@@ -41,15 +32,11 @@ else
 fi
 
 echo -e "\nDeploying into ${BRANCH} branch:"
-rm -rf *
-cp -R ${TEMP}/build/* .
+cp -R ${ORIGIN}/build/* .
 rm -rf ./*glob*
-cp -R "${TEMP}"/build/* .
 rm -f README.md
 git add .
 git commit -am "new version $(date)" --allow-empty
 git push origin "${BRANCH}" 2>&1 | sed 's|'$URL'|[skipped]|g'
 
-echo -e "\nCleaning up:"
-rm -rf "${CLONE}"
-rm -rf "${SITE}"
+echo -e "\nCleaning up: ${TEMP}"

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,7 @@ mv mgd-XXXX/* "${TMP}"
 CWD=$(pwd)
 git init "${TMP}"
 cd "${TMP}"
+bundle install
 touch "source/test.html"
 echo "hello" > "source/test.html"
 git add .


### PR DESCRIPTION
I think clone repository to build in it is a bit overkill.

On the other hand, I've some problems executing the build in a fresh new clone repository using external asset pipeline with webpack.

So I modify the deploy script to execute the build at current directory and only create a temp dir to move the build dir and deploy.